### PR TITLE
Code cleanup, reducing doubling, optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ A robust Ansible connection plugin that enables task execution inside FreeBSD ja
 
 ## Features
 
-- 🔒 **Secure**: Input validation, path sanitization, and shell injection protection
-- 🚀 **Performant**: Connection pooling and jail root path caching
-- 🛡️ **Robust**: Comprehensive error handling with retry logic and detailed error messages
-- 🔧 **Flexible**: Support for both `doas` and `sudo` privilege escalation
-- 📁 **File Transfer**: Two-stage file transfers with proper permission handling
-- 🧪 **Well-Tested**: Comprehensive unit test suite with 85%+ code coverage
-- 📖 **Well-Documented**: Extensive documentation and examples
+- **Secure**: Input validation, path sanitization, and shell injection protection
+- **Performant**: Connection pooling and jail root path caching
+- **Robust**: Comprehensive error handling with retry logic and detailed error messages
+- **Flexible**: Support for both `doas` and `sudo` privilege escalation
+- **File Transfer**: Two-stage file transfers with proper permission handling
+- **Well-Tested**: Comprehensive unit test suite with 85%+ code coverage
+- **Well-Documented**: Extensive documentation and examples
 
 ## Demo
 
@@ -372,8 +372,8 @@ This project is licensed under the BSD 2-Clause License - see the [LICENSE](LICE
 
 ## Support
 
-- 🐛 **Issues**: [GitHub Issues](https://github.com/chofstede/ansible_jailexec/issues)
-- 📧 **Email**: christian@hofstede.it
+- **Issues**: [GitHub Issues](https://github.com/chofstede/ansible_jailexec/issues)
+- **Email**: christian@hofstede.it
 
 ---
 


### PR DESCRIPTION
Summary

Code quality and maintainability improvements for the jailexec connection plugin. No functional changes - all optimizations are internal refactoring.

Changes

Constants & Pre-compilation

- Extract DANGEROUS_PATH_PATTERNS tuple to module level (was duplicated in 2 functions)
- Pre-compile HOME_DIR_PATTERN regex at module level for better performance

New Helper Methods

- Add _get_error_message() - consolidates repeated self._decode_output(result[2]) if result[2] else "Unknown error" pattern (was duplicated 4+ times)
- Add _build_host_command() - standardizes privilege escalation command building with proper shlex.quote() handling

Consolidated Methods

- Merge _transform_path() and _transform_path_only() into single method with validate parameter
  - _transform_path(path) - validates and transforms (default)
  - _transform_path(path, validate=False) - transforms only

Code Cleanup

- Add @functools.wraps to retry_on_failure decorator (preserves function metadata)
- Add guard in __del__ to prevent double-close and handle partial initialization
- Remove redundant .strip() calls in _get_jail_configuration()
- Remove dead code: or jail_user.isspace() (unreachable after .strip())
- Remove redundant validate_path_security() calls in put_file/fetch_file (validation now handled by _transform_path())

Test Plan

- All 89 unit tests pass
- Manual testing against real FreeBSD jail (ping, setup modules)