### PR TITLE
Add jail_root option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ ansible -i hosts.ini freebsd_jails -m community.general.pkgng -a "name=nginx sta
 |----------|---------|-------------|
 | `ansible_jail_name` | `inventory_hostname` | Override jail name |
 | `ansible_jail_user` | `root` | User for command execution in jail |
+| `ansible_jail_root` | automatic detection | Path of the jail |
 | `ansible_jail_privilege_escalation` | `doas` | Privilege escalation method (`doas` or `sudo`) |
 | `ansible_jail_remote_tmp` | `/tmp/.ansible/tmp` | Remote temporary directory |
 | `ansible_timeout` | `30` | Connection timeout in seconds |
@@ -141,26 +142,26 @@ All standard Ansible SSH options are supported:
   hosts: freebsd_jails
   connection: jailexec
   become: true
-  
+
   tasks:
     - name: Install nginx
       community.general.pkgng:
         name: nginx
         state: present
-    
+
     - name: Copy configuration
       ansible.builtin.copy:
         src: nginx.conf
         dest: /usr/local/etc/nginx/nginx.conf
         backup: true
       notify: restart nginx
-    
+
     - name: Start and enable nginx
       ansible.builtin.service:
         name: nginx
         state: started
         enabled: true
-  
+
   handlers:
     - name: restart nginx
       ansible.builtin.service:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -19,49 +19,49 @@ if parent_dir not in sys.path:
 
 class TestConnectionInitialization:
     """Test Connection class initialization."""
-    
+
     def test_connection_init_valid_jail_name(self, mock_play_context, mock_display):
         """Test successful connection initialization with valid jail name."""
         from jailexec import Connection
-        
+
         mock_play_context.remote_addr = "testjail"
-        
+
         with patch('jailexec.SSHConnection') as mock_ssh_base:
             conn = Connection(mock_play_context, None)
-            
+
             assert conn.jail_name == "testjail"
             assert conn.jail_user == "root"  # Default
             assert conn.privilege_escalation == "doas"  # Default
             assert conn.remote_tmp == "/tmp/.ansible/tmp"  # Default
-    
+
     def test_connection_init_invalid_jail_name(self, mock_play_context, mock_display):
         """Test connection initialization with invalid jail name."""
         from jailexec import Connection
-        
+
         mock_play_context.remote_addr = "invalid;jail"
-        
+
         with patch('jailexec.SSHConnection') as mock_ssh_base:
             with pytest.raises(AnsibleConnectionFailure, match="Invalid jail name format"):
                 Connection(mock_play_context, None)
-    
+
     def test_connection_init_custom_user(self, mock_play_context, mock_display):
         """Test connection initialization with custom user."""
         from jailexec import Connection
-        
+
         mock_play_context.remote_addr = "testjail"
         mock_play_context.remote_user = "testuser"
-        
+
         with patch('jailexec.SSHConnection') as mock_ssh_base:
             conn = Connection(mock_play_context, None)
             assert conn.jail_user == "testuser"
-    
+
     def test_connection_attributes_initialized(self, mock_play_context, mock_display):
         """Test that all connection attributes are properly initialized."""
         from jailexec import Connection
-        
+
         with patch('jailexec.SSHConnection') as mock_ssh_base:
             conn = Connection(mock_play_context, None)
-            
+
             # Check all attributes are initialized
             assert hasattr(conn, 'jail_name')
             assert hasattr(conn, 'jail_host')
@@ -72,7 +72,7 @@ class TestConnectionInitialization:
             assert hasattr(conn, '_jail_root_cache')
             assert hasattr(conn, '_host_connection')
             assert hasattr(conn, '_last_activity')
-            
+
             # Check initial values
             assert conn._jail_root_cache is None
             assert conn._host_connection is None
@@ -81,32 +81,32 @@ class TestConnectionInitialization:
 
 class TestConfigurationLoading:
     """Test configuration loading and validation."""
-    
+
     def test_get_jail_configuration_success(self, jail_connection, sample_config, test_helper):
         """Test successful configuration loading."""
         test_helper.mock_get_option(jail_connection, sample_config)
-        
+
         jail_connection._get_jail_configuration()
-        
+
         assert jail_connection.jail_host == sample_config['jail_host']
         assert jail_connection.jail_user == sample_config['jail_user']
         assert jail_connection.privilege_escalation == sample_config['privilege_escalation']
         assert jail_connection.remote_tmp == sample_config['remote_tmp']
-    
+
     def test_get_jail_configuration_missing_host(self, jail_connection, test_helper):
         """Test configuration loading with missing jail_host."""
         test_helper.mock_get_option(jail_connection, {})
-        
+
         with pytest.raises(AnsibleConnectionFailure, match="No jail host specified"):
             jail_connection._get_jail_configuration()
-    
+
     def test_get_jail_configuration_empty_host(self, jail_connection, test_helper):
         """Test configuration loading with empty jail_host."""
         test_helper.mock_get_option(jail_connection, {'jail_host': '   '})
-        
+
         with pytest.raises(AnsibleConnectionFailure, match="No jail host specified"):
             jail_connection._get_jail_configuration()
-    
+
     def test_get_jail_configuration_invalid_privilege_escalation(self, jail_connection, test_helper):
         """Test configuration loading with invalid privilege escalation method."""
         config = {
@@ -114,10 +114,10 @@ class TestConfigurationLoading:
             'privilege_escalation': 'invalid_method'
         }
         test_helper.mock_get_option(jail_connection, config)
-        
+
         with pytest.raises(AnsibleConnectionFailure, match="Invalid privilege escalation method"):
             jail_connection._get_jail_configuration()
-    
+
     def test_get_jail_configuration_invalid_remote_tmp(self, jail_connection, test_helper):
         """Test configuration loading with invalid remote_tmp path."""
         config = {
@@ -125,10 +125,10 @@ class TestConfigurationLoading:
             'remote_tmp': 'relative/path'  # Not absolute
         }
         test_helper.mock_get_option(jail_connection, config)
-        
+
         with pytest.raises(AnsibleConnectionFailure, match="must be an absolute path"):
             jail_connection._get_jail_configuration()
-    
+
     def test_get_jail_configuration_dangerous_remote_tmp(self, jail_connection, test_helper):
         """Test configuration loading with dangerous remote_tmp path."""
         config = {
@@ -136,10 +136,10 @@ class TestConfigurationLoading:
             'remote_tmp': '/tmp/../etc'  # Path traversal
         }
         test_helper.mock_get_option(jail_connection, config)
-        
+
         with pytest.raises(AnsibleConnectionFailure):
             jail_connection._get_jail_configuration()
-    
+
     def test_get_jail_configuration_jail_name_override(self, jail_connection, test_helper):
         """Test jail name override in configuration."""
         config = {
@@ -147,13 +147,13 @@ class TestConfigurationLoading:
             'jail_name': 'overridden-jail'
         }
         test_helper.mock_get_option(jail_connection, config)
-        
+
         original_name = jail_connection.jail_name
         jail_connection._get_jail_configuration()
-        
+
         assert jail_connection.jail_name == 'overridden-jail'
         assert jail_connection.jail_name != original_name
-    
+
     def test_get_jail_configuration_invalid_jail_name_override(self, jail_connection, test_helper):
         """Test invalid jail name override in configuration."""
         config = {
@@ -161,10 +161,10 @@ class TestConfigurationLoading:
             'jail_name': 'invalid;jail'
         }
         test_helper.mock_get_option(jail_connection, config)
-        
+
         with pytest.raises(AnsibleConnectionFailure, match="Invalid jail name format"):
             jail_connection._get_jail_configuration()
-    
+
     def test_get_jail_configuration_timeout_validation(self, jail_connection, test_helper):
         """Test timeout configuration validation."""
         config = {
@@ -172,38 +172,38 @@ class TestConfigurationLoading:
             'timeout': 60
         }
         test_helper.mock_get_option(jail_connection, config)
-        
+
         jail_connection._get_jail_configuration()
         assert jail_connection.connection_timeout == 60
-        
+
         # Test invalid timeout
         config['timeout'] = 'invalid'
         test_helper.mock_get_option(jail_connection, config)
-        
+
         # Should not raise exception, just use default
         jail_connection._get_jail_configuration()
 
 
 class TestSSHConnectionManagement:
     """Test SSH connection creation and management."""
-    
+
     def test_create_ssh_connection_success(self, jail_connection, mock_display):
         """Test successful SSH connection creation."""
         jail_connection.jail_host = "host.example.com"
-        
+
         with patch('jailexec.SSHConnection') as mock_ssh_class:
             mock_ssh_instance = Mock()
             mock_ssh_class.return_value = mock_ssh_instance
-            
+
             result = jail_connection._create_ssh_connection()
-            
+
             assert result == mock_ssh_instance
             mock_ssh_instance._connect.assert_called_once()
-    
+
     def test_create_ssh_connection_with_retry(self, jail_connection, mock_display):
         """Test SSH connection creation with retry logic."""
         jail_connection.jail_host = "host.example.com"
-        
+
         with patch('jailexec.SSHConnection') as mock_ssh_class:
             mock_ssh_instance = Mock()
             mock_ssh_instance._connect.side_effect = [
@@ -211,65 +211,65 @@ class TestSSHConnectionManagement:
                 None  # Second attempt succeeds
             ]
             mock_ssh_class.return_value = mock_ssh_instance
-            
+
             result = jail_connection._create_ssh_connection()
-            
+
             assert result == mock_ssh_instance
             assert mock_ssh_instance._connect.call_count == 2
-    
+
     def test_create_ssh_connection_all_retries_fail(self, jail_connection, mock_display):
         """Test SSH connection creation when all retries fail."""
         jail_connection.jail_host = "host.example.com"
-        
+
         with patch('jailexec.SSHConnection') as mock_ssh_class:
             mock_ssh_instance = Mock()
             mock_ssh_instance._connect.side_effect = AnsibleConnectionFailure("Connection failed")
             mock_ssh_class.return_value = mock_ssh_instance
-            
+
             with pytest.raises(AnsibleConnectionFailure, match="Connection failed"):
                 jail_connection._create_ssh_connection()
 
 
 class TestConnectionLifecycle:
     """Test connection lifecycle methods."""
-    
+
     def test_connect_full_lifecycle(self, jail_connection, sample_config, test_helper, mock_ssh_connection):
         """Test full connection lifecycle."""
         # Setup configuration
         test_helper.mock_get_option(jail_connection, sample_config)
-        
+
         # Setup SSH connection mock
         jail_connection._host_connection = mock_ssh_connection
-        
+
         # Setup successful jail verification
         test_helper.setup_ssh_exec_results(mock_ssh_connection, {
             'doas jls -j testjail': (0, b"testjail running", b"")
         })
-        
+
         # Test connection
         result = jail_connection._connect()
-        
+
         assert result == jail_connection
         assert jail_connection._connected is True
         assert jail_connection.jail_host == sample_config['jail_host']
-    
+
     def test_connect_already_connected(self, jail_connection):
         """Test connection when already connected."""
         jail_connection._connected = True
-        
+
         result = jail_connection._connect()
-        
+
         assert result == jail_connection
         # Should not attempt to reconnect
-    
+
     def test_close_connection(self, jail_connection, mock_ssh_connection):
         """Test connection cleanup."""
         jail_connection._host_connection = mock_ssh_connection
         jail_connection._jail_root_cache = "/jail/root"
         jail_connection._connected = True
-        
+
         jail_connection.close()
-        
+
         assert mock_ssh_connection.connected is False
         assert jail_connection._jail_root_cache is None
         assert jail_connection._host_connection is None


### PR DESCRIPTION
Since in mail jail setups, the automatic detection of the jail_root fails, I added the `jail_root` option to specify the jail's root directory manually.