### PR TITLE
Release 2.0.0: fix jail-escape in file transfers + correctness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,10 @@ cython_debug/
 *.retry
 hosts
 inventory
-test-inventory
+# Local integration-test inventories contain real host addresses/credentials;
+# only the .example template belongs in the repo.
+test-inventory*
+!test-inventory.ini.example
 # Local ansible.cfg used to point Ansible at this checkout for dev/testing.
 ansible.cfg
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project are documented here.
 Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses [Semantic Versioning](https://semver.org/).
 
+## [2.0.0] - 2026-06-10
+
+**Security release — upgrading is strongly recommended.** The file-transfer mechanism was rewritten to run inside the jail and the release was verified end-to-end against a real FreeBSD 15.0 jail host (`tests/integration/smoke-test.yml`).
+
+### Security
+- **Closed a jail-escape vector in file transfers.** `put_file` used to run `mkdir -p` and `mv` **on the host**, as root, against `<jail root>/<destination>`. Because those commands resolve symlinks, a compromised jail could plant a symlink (e.g. its `/usr/local/etc` pointing at the host's `/etc`) and turn any playbook copy through that path into a root-owned write to an arbitrary host file. Transfers now execute **inside** the jail (`jexec <jail> /bin/sh -c 'mkdir -p … && cat > dest' < staged-file`), so every path resolves within the jail's chroot and cannot reach the host filesystem. `fetch_file` reads through `jexec` the same way.
+
+### Fixed
+- The default jail name is now the **inventory hostname**, as documented. Previously it fell back to the connection address, so an inventory line like `web ansible_host=192.0.2.10 …` ran `jexec "192.0.2.10"` and failed with `jexec: jail "192.0.2.10" not found`. An explicit `ansible_jail_name` still wins.
+- The bundled integration-test files were stale: `test-inventory.ini.example` used `ansible_host` instead of the required `ansible_jail_host` and set `ansible_become=yes` globally (which needs doas *inside* the jail); `smoke-test.yml` referenced facts with `gather_facts: no`. The smoke test now also round-trips a file through `put_file`/`slurp`/`fetch_file`.
+- `ansible_jail_user` is now passed as `jexec -U` (resolved in the **jail's** password database) instead of `-u` (the **host's**). Previously a user like `postgres` that exists only inside the jail failed with `jexec: : unknown user`, and a same-named host user with a different UID ran with the wrong credentials.
+- `fetch_file` now goes through privilege escalation. Previously it pulled the file over SFTP as the plain SSH user from the host-side path, so files readable only by root inside the jail could not be fetched at all.
+- Plugin-internal commands (transfer plumbing, staging cleanup) now pass `sudoable=False` to the SSH layer. With `become: yes` plus a become password, the SSH plugin used to wait for a privilege-escalation prompt that never appears on these internal commands and timed out; this also stops them from allocating an unnecessary `-tt` pseudo-terminal.
+
+### Changed
+- **Transfers now run as `ansible_jail_user` inside the jail** instead of always as root on the host. This matches the standard connection-plugin contract (transferred files are owned by the connection user, and permission fix-ups work). If you relied on copying to root-owned paths while `ansible_jail_user` was non-root, add `become: yes` to those tasks.
+- **Host-side privilege requirements shrank to `jexec` alone.** The `jls`, `mkdir`, `mv`, and `rm` doas/sudo rules are no longer used and can be removed from `doas.conf`/`sudoers`.
+- The jail-root probe (`jls -j <name> path`) is gone entirely; the plugin issues zero extra round trips before the first task regardless of workload.
+- `fetch_file` stages through the host (created with `umask 077`) and costs two extra round trips compared to 1.x; `put_file` round trips are unchanged.
+- Jails must provide `/bin/sh` and `cat` (both are part of the FreeBSD base system; `exec_command` already required `/bin/sh`).
+
+### Deprecated
+- `ansible_jail_root` is now ignored and produces a warning when set. The on-host jail path is no longer used for anything, and the nested/VNET-jail probe problem it worked around (#4) no longer exists.
+
 ## [1.3.0] - 2026-06-05
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,14 @@ include CHANGELOG.md
 include LICENSE
 include requirements-test.txt
 include pytest.ini
-recursive-include tests *.py *.yml *.ini *.example
+recursive-include tests *.py *.yml *.example
 recursive-include tests/integration *.md
 global-exclude __pycache__
 global-exclude *.py[cod]
+# Never ship local integration inventories (they hold real hosts/credentials);
+# only the committed *.example template belongs in the sdist.
+global-exclude test-inventory.ini
+prune dist
+prune build
+prune htmlcov
+prune .venv

--- a/README.md
+++ b/README.md
@@ -5,28 +5,42 @@
 [![ansible-core: 2.14+](https://img.shields.io/badge/ansible--core-2.14+-red.svg)](https://docs.ansible.com/)
 [![CI](https://github.com/chofstede/ansible_jailexec/workflows/CI/badge.svg)](https://github.com/chofstede/ansible_jailexec/actions)
 
-An Ansible connection plugin that runs tasks **inside a FreeBSD jail** by SSH-ing to the jail host and wrapping every command in `jexec`. You do **not** need direct SSH access to the jail itself.
+An Ansible connection plugin that runs tasks **inside a FreeBSD jail** by SSH-ing to the jail host and wrapping every command in `jexec`. You do **not** need direct SSH access to the jail itself — the jail needs no sshd, no Python-over-SSH setup, no network address of its own.
 
 The plugin inherits from Ansible's built-in `ssh` connection plugin, so every SSH option (control persist, jump hosts, key files, custom ports, etc.) works unchanged.
 
 ## Features
 
 - **Inherits the full SSH plugin**: options are merged from the live `ssh` plugin at import time, so the plugin stays in sync with whichever `ansible-core` is installed.
-- **Safe by construction**: jail names are validated, paths are traversal-checked, and every shell argument is `shlex.quote`d.
-- **Lazy jail-root probe**: the on-host path of the jail is resolved only on the first file transfer, so exec-only workloads pay zero extra round trips.
-- **Single round-trip `put_file`**: staged file is moved into the jail with one combined `mkdir -p && mv` command.
-- **`doas` or `sudo`** for host-side privilege escalation around `jls`/`jexec`/`mkdir`/`mv`/`rm`.
+- **Everything happens inside the jail**: commands *and file transfers* run through `jexec`, confined to the jail's chroot. A symlink planted inside a jail can never redirect a privileged write or read onto a host path.
+- **Safe by construction**: jail names are validated, paths are traversal-checked and normalized, and every shell argument is `shlex.quote`d.
+- **Minimal host footprint**: the SSH user needs a `doas`/`sudo` rule for exactly one command — `jexec`.
+- **Zero extra round trips for exec-only workloads**: no probing at connect time; `put_file` costs a single extra exec.
+- **`doas`, `sudo`, or `none`** for host-side privilege escalation around `jexec`.
 
 ## Demo
 
 ![Plugin in Action](screenshot.png)
 *Executing Ansible tasks inside FreeBSD jails through the `jailexec` connection plugin.*
 
+## How it works
+
+For every task, the plugin opens a normal SSH session to the **jail host** (reusing ControlPersist connections like the stock `ssh` plugin) and runs:
+
+```
+doas jexec [-U <jail_user>] <jail_name> /bin/sh -c '<command>'
+```
+
+File transfers stage through the host and complete inside the jail:
+
+- **put_file**: upload to a random `/tmp/ansible-jailexec-<hex>` name on the host via SFTP, then `doas jexec <jail> /bin/sh -c 'mkdir -p <dir> && cat > <dest>' < <staged>` — the write resolves entirely within the jail's filesystem namespace.
+- **fetch_file**: `doas jexec <jail> /bin/sh -c 'cat < <src>' > <staged>` (staged copy created with `umask 077`), then download via SFTP and remove the staged copy.
+
 ## Requirements
 
 - **Control machine**: Python 3.9+, `ansible-core >= 2.14`
-- **Jail host**: FreeBSD with `jls` and `jexec` available, and `doas` or `sudo` configured for the SSH user
-- **Jails**: must be running (so `jls -j <name> path` returns their filesystem root)
+- **Jail host**: FreeBSD with `jexec` available, and `doas` or `sudo` configured for the SSH user (not needed if you SSH in as root — see `ansible_jail_privilege_escalation=none`)
+- **Jails**: must be running, with `/bin/sh` and `cat` available (both ship in the FreeBSD base system), plus Python for Ansible modules as usual
 
 ## Installation
 
@@ -72,7 +86,7 @@ db-jail   ansible_connection=jailexec  ansible_jail_host=jail-host.example.com  
 app-jail  ansible_connection=jailexec  ansible_jail_host=jail-host.example.com  ansible_ssh_port=30822
 ```
 
-The inventory hostname (`web-jail`, `db-jail`, …) doubles as the jail name unless you override it with `ansible_jail_name`.
+The inventory hostname (`web-jail`, `db-jail`, …) doubles as the jail name unless you override it with `ansible_jail_name`. Setting `ansible_host` does not affect the jail name — it is an SSH-level alias for the jail host's address, like `ansible_jail_host`.
 
 ### 2. Ping
 
@@ -104,9 +118,9 @@ ansible -i hosts.ini freebsd_jails -m community.general.pkgng -a "name=nginx sta
 |----------|----------|---------|-------------|
 | `ansible_jail_host` | ✅ | — | Hostname or IP of the FreeBSD host that runs the jail. |
 | `ansible_jail_name` | | inventory hostname | Override the jail name if it differs from the inventory hostname. |
-| `ansible_jail_user` | | `root` | User to run commands as inside the jail. |
-| `ansible_jail_root` | | auto-detected via `jls -j <name> path` | Absolute on-host path of the jail. Set this for nested or VNET jail setups where the probe returns an unexpected path. |
-| `ansible_jail_privilege_escalation` | | `doas` | Host-side privilege escalation for `jls`/`jexec`. One of `doas`, `sudo`, `none`. Use `none` when you already SSH to the host as root and have no `doas`/`sudo`. |
+| `ansible_jail_user` | | `root` | User to run commands (and file transfers) as inside the jail, resolved against the **jail's** password database (`jexec -U`). |
+| `ansible_jail_privilege_escalation` | | `doas` | Host-side privilege escalation for `jexec`. One of `doas`, `sudo`, `none`. Use `none` when you already SSH to the host as root and have no `doas`/`sudo`. |
+| `ansible_jail_root` | | — | **Deprecated, ignored since 2.0.0.** Transfers run inside the jail via `jexec`, so the jail's on-host path is no longer needed. Setting it only produces a warning. |
 
 ### SSH options
 
@@ -122,29 +136,31 @@ ansible-doc -t connection ssh
 
 There are **two** places where privileges can be escalated, and it's easy to conflate them:
 
-1. **`ansible_jail_privilege_escalation`** (this plugin) — runs `jls`/`jexec`/`mkdir`/`mv`/`rm` **on the host** as root so the plugin can enter the jail and write into its filesystem. Default: `doas`. Set it to `none` when the SSH user is already root on the host (so no `doas`/`sudo` is installed); the plugin then invokes `jexec` directly.
+1. **`ansible_jail_privilege_escalation`** (this plugin) — runs `jexec` **on the host** as root so the plugin can enter the jail. Default: `doas`. Set it to `none` when the SSH user is already root on the host (so no `doas`/`sudo` is installed); the plugin then invokes `jexec` directly.
 2. **Ansible `become`** (`become: yes`, `--become`, `ansible_become_method`) — runs the **task payload inside the jail** under a different user. Use this if `ansible_jail_user` is non-root and the task needs root inside the jail.
 
 Typical setup: leave `ansible_jail_user=root` (the default) and skip `become` entirely; the plugin's own privilege escalation is already enough.
 
+Note that with a non-root `ansible_jail_user`, file transfers also run as that user inside the jail — copying to root-owned locations then requires `become`, exactly as it would over plain SSH.
+
 ## FreeBSD host setup
 
-Add the SSH user to `doas`:
+The SSH user needs to run exactly one command as root: `jexec`.
+
+Add it to `doas`:
 
 ```
 # /usr/local/etc/doas.conf
-permit nopass ansible as root cmd jls
 permit nopass ansible as root cmd jexec
-permit nopass ansible as root cmd mkdir
-permit nopass ansible as root cmd mv
-permit nopass ansible as root cmd rm
 ```
 
 or to `sudoers` (edit with `visudo`):
 
 ```
-ansible ALL=(root) NOPASSWD: /usr/sbin/jls, /usr/sbin/jexec, /bin/mkdir, /bin/mv, /bin/rm
+ansible ALL=(root) NOPASSWD: /usr/sbin/jexec
 ```
+
+> Upgrading from 1.x? The `jls`, `mkdir`, `mv`, and `rm` rules that earlier versions needed are no longer used and can be removed.
 
 ## Playbook example
 
@@ -179,6 +195,15 @@ ansible ALL=(root) NOPASSWD: /usr/sbin/jls, /usr/sbin/jexec, /bin/mkdir, /bin/mv
         state: restarted
 ```
 
+## Upgrading from 1.x
+
+Version 2.0.0 moves all file transfers *inside* the jail (see [Security considerations](#security-considerations) and the [CHANGELOG](CHANGELOG.md)). For typical setups (`ansible_jail_user=root`) no inventory change is needed. Things to check:
+
+- **doas/sudoers** can be trimmed to the single `jexec` rule shown above.
+- **`ansible_jail_root`** is ignored (with a warning) — simply remove it; the path-mapping problem it worked around no longer exists.
+- **`ansible_jail_user`** is now resolved in the *jail's* password database (`jexec -U`), as the documentation always promised. If you depended on the host's password database (`jexec -u` semantics), align the user accounts or use `become`.
+- **Transfers run as `ansible_jail_user`**, no longer silently as root. Non-root jail users writing to root-owned paths need `become: yes`.
+
 ## Troubleshooting
 
 Enable verbose mode:
@@ -190,7 +215,6 @@ ansible -vvv -i hosts.ini freebsd_jails -m ping
 Plugin log lines are prefixed with `jailexec:`:
 
 ```
-jailexec: jail 'web-jail' root is /jail/web-jail
 jailexec: exec [web-jail]: /bin/sh -c 'echo hi'
 jailexec: put_file /local/nginx.conf -> jail:/usr/local/etc/nginx/nginx.conf
 jailexec: fetch_file jail:/var/log/nginx/access.log -> /tmp/access.log
@@ -201,18 +225,24 @@ jailexec: fetch_file jail:/var/log/nginx/access.log -> /tmp/access.log
 | Message | Cause | Fix |
 |---------|-------|-----|
 | `ansible_jail_host is not set for jail 'X'` | Missing inventory variable. | Add `ansible_jail_host=<host>` to inventory. |
-| `Cannot access jail 'X': …` | `jls -j X path` failed on the host. Typically the jail isn't running or `doas`/`sudo` rejected `jls`. | `doas jls` on the host; check `service jail status`. |
-| `Jail 'X' returned no filesystem root (is it running?)` | `jls` succeeded but returned blank. Jail defined but not started. | `service jail onestart X`. |
+| `jexec: jail "X" not found` (in task stderr) | The jail isn't running, or the name is wrong. | `jls` on the host; `service jail onestart X`; check `ansible_jail_name`. |
+| `doas: not found` / `sudo: not found` (exit 127) | No privilege-escalation helper on the host. | Install/configure `doas`, or set `ansible_jail_privilege_escalation=none` when SSH-ing in as root. |
+| `doas: Operation not permitted` / `sudo: a password is required` | The SSH user has no (passwordless) rule for `jexec`. | Add the `doas.conf`/`sudoers` rule shown above. |
 | `Invalid jail name 'X': …` | Jail name contains shell-unsafe characters or starts with `-`/`.`. | Rename, or use `ansible_jail_name` to override. |
 | `Path contains '..' traversal: X` | A module tried to `put_file`/`fetch_file` with `..` in the path. | Use absolute paths without `..` segments. |
-| `put_file to jail:X failed: …` | `mkdir`/`mv` into the jail root failed (permissions, full disk). | Check host-side `doas`/`sudo` rules and free space. |
+| `put_file to jail:X failed: …` | Writing inside the jail failed (permissions, read-only filesystem, full disk). | Check the path and `ansible_jail_user`'s rights inside the jail; use `become` for root-owned paths. |
+| `fetch_file from jail:X failed: …` | Reading inside the jail failed (missing file, permissions). | Verify the path exists and is readable by `ansible_jail_user`. |
+| `ansible_jail_root is deprecated and ignored` (warning) | Leftover 1.x inventory variable. | Remove `ansible_jail_root`; it is no longer needed. |
 
 ## Security considerations
 
-- **Input validation**: jail names are matched against `^[A-Za-z0-9_][A-Za-z0-9._-]*$` and length-capped at 255. Paths are rejected if any component is `..`.
-- **Shell safety**: every argument crossing the SSH wire is `shlex.quote`d; the user-supplied command is the final argument to `/bin/sh -c` and is *not* further interpreted by the plugin.
-- **File transfers**: files are staged in `/tmp` on the host with a random name (`ansible-jailexec-<hex>`), then moved into the jail using the configured privilege-escalation helper. On move failure, the staged file is best-effort removed.
+- **Transfers are confined to the jail**: `put_file` and `fetch_file` execute `mkdir`/`cat` *inside* the jail via `jexec`, so all path resolution happens within the jail's chroot. A symlink planted inside a (potentially compromised) jail cannot redirect a privileged write or read to a host path. (Versions before 2.0.0 performed root-owned `mv` operations on host-side paths and were vulnerable to exactly that — upgrade.)
+- **Input validation**: jail names are matched against `^[A-Za-z0-9_][A-Za-z0-9._-]*$` and length-capped at 255. Paths are rejected if any component is `..`, and are normalized to absolute in-jail paths.
+- **Shell safety**: every argument crossing the SSH wire is `shlex.quote`d; the user-supplied command is the final argument to `/bin/sh -c` and is *not* further interpreted by the plugin. Fetched files are read with `cat < file` redirection, ruling out option injection.
+- **File staging**: transfers stage in `/tmp` on the host under a random name (`ansible-jailexec-<hex>`, 96 bits of randomness). Fetched files are staged with `umask 077` so they are never world-readable; staged files are removed even when the transfer fails.
+- **Minimal escalation surface**: the only command the SSH user runs via `doas`/`sudo` is `jexec`.
 - **No new network ports**: everything rides the existing SSH connection, including control-persist reuse.
+- **Internal plumbing never engages `become`**: plugin-internal commands run with `sudoable=False`, so they neither wait for become prompts nor allocate pseudo-terminals.
 
 ## Development
 
@@ -220,11 +250,14 @@ jailexec: fetch_file jail:/var/log/nginx/access.log -> /tmp/access.log
 # Install test dependencies
 pip install -r requirements-test.txt
 
-# Run the test suite with coverage
+# Run the test suite with coverage (gate: 100%)
 pytest
 
-# Syntax check
-python3 -m py_compile jailexec.py
+# Format / lint / security scan (same as CI)
+black jailexec.py tests/
+isort jailexec.py tests/
+flake8 jailexec.py --max-line-length=100 --extend-ignore=E203,W503
+bandit -r jailexec.py
 ```
 
 See [`tests/integration/README.md`](tests/integration/README.md) for end-to-end tests against a real FreeBSD host.
@@ -236,3 +269,4 @@ BSD 2-Clause — see [LICENSE](LICENSE).
 ## Support
 
 - Issues: https://github.com/chofstede/ansible_jailexec/issues
+- Changelog: [CHANGELOG.md](CHANGELOG.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 2.0.x   | ✅ |
+| < 2.0   | ❌ (contains a known jail-escape vulnerability — see below) |
+
+## Reporting a vulnerability
+
+Please report security issues **privately**, not via public issues or pull requests:
+
+- Preferred: open a private report through GitHub Security Advisories
+  ([Report a vulnerability](https://github.com/chofstede/ansible_jailexec/security/advisories/new)).
+- Alternatively, email the maintainer at `christian@hofstede.it`.
+
+Please include enough detail to reproduce (plugin version, `ansible-core` version,
+inventory shape, and the behavior observed). You will receive an acknowledgement, and
+we will coordinate a fix and disclosure timeline with you.
+
+## Known advisories
+
+- **< 2.0.0 — jail escape via symlink in `put_file`.** File transfers resolved paths on
+  the host and performed root-owned `mv` operations that followed symlinks placed inside
+  a jail, allowing arbitrary root-owned writes on the host. Fixed in 2.0.0 by performing
+  all transfers inside the jail via `jexec`. See
+  [`docs/security/advisory-2.0.0-jail-escape.md`](docs/security/advisory-2.0.0-jail-escape.md).

--- a/docs/security/advisory-2.0.0-jail-escape.md
+++ b/docs/security/advisory-2.0.0-jail-escape.md
@@ -1,0 +1,78 @@
+# Security Advisory: jail escape via symlink in `put_file` (fixed in 2.0.0)
+
+| | |
+|---|---|
+| **Affected** | `ansible-jailexec` (the `jailexec` connection plugin), all releases `< 2.0.0` |
+| **Fixed in** | `2.0.0` |
+| **Severity** | High |
+| **CWE** | CWE-59 (Improper Link Resolution Before File Access / symlink following), CWE-61 |
+| **Vector (CVSS 3.1)** | `AV:N/AC:H/PR:H/UI:N/S:C/C:H/I:H/A:H` (scope-changed: jail → host) |
+
+## Summary
+
+Through version 1.3.0, the plugin's `put_file` implementation resolved a transfer's
+destination to a path on the **jail host** (`<jail filesystem root> + <destination>`)
+and then created directories and moved the staged file into place by running, **as
+root on the host**:
+
+```
+doas jexec ...        # NO — exec went through jexec, but the transfer did not:
+doas mkdir -p <jail_root>/<dir>
+doas mv <staged> <jail_root>/<dest>
+```
+
+`mkdir` and `mv` resolve symbolic links. Because the path was assembled and operated
+on **outside** the jail, a symlink that exists **inside** the jail's filesystem was
+followed by the host-side, root-privileged `mv`. A user who controls content inside a
+jail (the jail's own root, or any process able to create a symlink in a directory an
+Ansible task later writes to) could therefore cause a privileged write to an arbitrary
+path on the **host**, outside the jail.
+
+This breaks the core guarantee of the plugin: that tasks are confined to the target
+jail.
+
+## Impact
+
+An attacker with control over a jail managed by this plugin can escalate to arbitrary
+**host** file writes as root, and (in 2.0.0's corrected read path, by analogy in older
+versions wherever a privileged read occurred) influence what is read. Arbitrary
+root-owned writes on the host are readily escalated to full host compromise (e.g.
+writing to `/etc/crontab`, `/usr/local/etc/rc.d`, an `authorized_keys` file, etc.).
+
+Preconditions:
+- The operator runs a playbook with a `copy`/`template`/`fetch`-style task (anything
+  using `put_file`) targeting the jail.
+- The attacker can place a symlink inside the jail at or above the task's destination
+  path before the transfer runs.
+
+## The fix (2.0.0)
+
+File transfers now run **inside** the jail through `jexec`, so every path is resolved
+within the jail's chroot and cannot reference the host filesystem:
+
+- `put_file`: `jexec <jail> /bin/sh -c 'mkdir -p <dir> && cat > <dest>' < <staged>`
+- `fetch_file`: `jexec <jail> /bin/sh -c 'cat < <src>' > <staged>`, then download
+
+A symlink inside the jail can at most redirect the write/read to another location
+**inside the same jail** — which the jail's own user already controls — and can no
+longer reach the host.
+
+## Workarounds
+
+There is no configuration-level workaround in affected versions; upgrade to 2.0.0.
+As defense in depth, treat any jail as untrusted and avoid running file-transfer tasks
+against jails you do not fully control until upgraded.
+
+## Remediation
+
+Upgrade to `ansible-jailexec >= 2.0.0`. For the common `ansible_jail_user=root`
+configuration no inventory changes are required; see the README "Upgrading from 1.x"
+section. Host-side `doas`/`sudo` rules can be reduced to a single `jexec` entry.
+
+## Credit
+
+Found during a security review of the plugin.
+
+## Timeline
+
+- 2026-06-10 — Issue identified during code review; fix developed and released as 2.0.0.

--- a/jailexec.py
+++ b/jailexec.py
@@ -42,9 +42,14 @@ DOCUMENTATION = """
     version_added: "1.1.0"
     options:
         jail_name:
-            description: Jail name. Defaults to the inventory hostname.
+            description:
+                - Jail name. Defaults to the inventory hostname (not to
+                  ansible_host, which is the address of the jail host).
             type: str
             vars:
+                # Later entries win: an explicit ansible_jail_name overrides
+                # the inventory_hostname default.
+                - name: inventory_hostname
                 - name: ansible_jail_name
         jail_host:
             description: Hostname or IP of the FreeBSD host that runs the jail.
@@ -54,18 +59,18 @@ DOCUMENTATION = """
                 - name: ansible_jail_host
         jail_root:
             description:
-                - Absolute on-host filesystem path of the jail, used as the
-                  base for put_file and fetch_file.
-                - If unset, the plugin probes the host with
-                  ``jls -j <name> path`` on the first file transfer.
-                - Set this for nested or VNET jail setups where the probe
-                  does not return the expected path.
+                - Deprecated and ignored since 2.0.0. File transfers now run
+                  inside the jail via jexec, so the plugin no longer needs
+                  the jail's on-host filesystem path.
+                - Setting it produces a warning and has no other effect.
             type: str
             version_added: "1.2.0"
             vars:
                 - name: ansible_jail_root
         jail_user:
-            description: User to run commands as inside the jail.
+            description:
+                - User to run commands as inside the jail, resolved against
+                  the jail's password database (``jexec -U``).
             type: str
             default: root
             vars:
@@ -108,8 +113,9 @@ MAX_JAIL_NAME_LENGTH = 255
 JAIL_NAME_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]*$")
 PRIVESC_CHOICES = ("doas", "sudo", "none")
 # /tmp is on the remote jail host, not the Ansible controller. File names are
-# randomized via ``os.urandom`` in ``put_file``, which defeats predictable-name
-# attacks. Bandit's B108 check is about local-tmp usage and does not apply.
+# randomized via ``os.urandom`` in ``_staging_path``, which defeats
+# predictable-name attacks. Bandit's B108 check is about local-tmp usage and
+# does not apply.
 STAGING_DIR = "/tmp"  # nosec B108
 STAGING_PREFIX = "ansible-jailexec-"
 
@@ -138,22 +144,6 @@ def ensure_no_traversal(path):
         raise AnsibleError(f"Path contains '..' traversal: {path}")
 
 
-def validate_jail_root(path):
-    """Normalize and validate a user-provided jail-root override.
-
-    Must be a non-empty absolute POSIX path without any ``..`` components.
-    """
-    path = (path or "").strip()
-    if not path:
-        raise AnsibleConnectionFailure("ansible_jail_root cannot be empty")
-    if not path.startswith("/"):
-        raise AnsibleConnectionFailure(
-            f"ansible_jail_root must be an absolute path, got {path!r}"
-        )
-    ensure_no_traversal(path)
-    return posixpath.normpath(path)
-
-
 def _decode(data):
     """Return ``data`` as a str. Bytes are decoded leniently; None becomes ''."""
     if data is None:
@@ -173,10 +163,6 @@ class Connection(SSHConnection):
 
     transport = "jailexec"
     has_pipelining = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._jail_root = None
 
     # ---- options ---------------------------------------------------------
 
@@ -212,6 +198,18 @@ class Connection(SSHConnection):
         value = self.privesc
         return [] if value == "none" else [value]
 
+    def _jexec_argv(self):
+        """Shared ``[doas] jexec [-U user] <jail>`` prefix for remote calls.
+
+        ``-U`` resolves the user against the *jail's* password database;
+        ``-u`` would consult the host's, which is not what jail_user means.
+        """
+        argv = [*self._privesc_argv(), "jexec"]
+        if self.jail_user != "root":
+            argv += ["-U", self.jail_user]
+        argv.append(self.jail_name)
+        return argv
+
     # ---- connect / lifecycle --------------------------------------------
 
     def _connect(self):
@@ -223,6 +221,12 @@ class Connection(SSHConnection):
             raise AnsibleConnectionFailure(
                 f"ansible_jail_host is not set for jail {self.jail_name!r}"
             )
+        if self.get_option("jail_root"):
+            display.warning(
+                "ansible_jail_root is deprecated and ignored: file transfers "
+                "now run inside the jail via jexec, so the jail's on-host "
+                "path is no longer needed."
+            )
         # Redirect the inherited SSH plugin at the jail *host* instead of the
         # jail (inventory) name. This is the one hook we need -- everything
         # else comes from the SSH base class.
@@ -231,59 +235,25 @@ class Connection(SSHConnection):
         # SSH's _connect is a no-op on _connected, but ConnectionBase's
         # exec_command/put_file/fetch_file are wrapped with @ensure_connect,
         # which re-enters self._connect() whenever _connected is False. We
-        # flip it here so the jail-root probe issued on first file op (via
-        # super().exec_command) doesn't recurse into us.
+        # flip it here so the internal commands issued by put_file/fetch_file
+        # (via super().exec_command) don't recurse into us.
         self._connected = True
         return self
 
-    def close(self):
-        self._jail_root = None
-        super().close()
+    # ---- paths -----------------------------------------------------------
 
-    # ---- jail metadata ---------------------------------------------------
-
-    def _resolve_jail_root(self):
-        """Look up and cache the on-host filesystem path of the jail.
-
-        If ``ansible_jail_root`` is set, that value is used verbatim and no
-        SSH probe happens. Otherwise the path is resolved via
-        ``jls -j <name> path`` on the first file operation, then cached.
-        """
-        if self._jail_root:
-            return self._jail_root
-
-        override = self.get_option("jail_root")
-        if override:
-            self._jail_root = validate_jail_root(override)
-            display.vvv(
-                f"jailexec: jail {self.jail_name!r} root is {self._jail_root} "
-                "(from ansible_jail_root)",
-                host=self.jail_name,
-            )
-            return self._jail_root
-
-        name = self.jail_name
-        rc, stdout, stderr = super().exec_command(
-            _shelljoin(*self._privesc_argv(), "jls", "-j", name, "path")
-        )
-        if rc != 0:
-            msg = _decode(stderr).strip() or "jail not found or inaccessible"
-            raise AnsibleConnectionFailure(f"Cannot access jail {name!r}: {msg}")
-        lines = _decode(stdout).strip().splitlines()
-        root = lines[0].strip() if lines else ""
-        if not root:
-            raise AnsibleConnectionFailure(
-                f"Jail {name!r} returned no filesystem root (is it running?)"
-            )
-        self._jail_root = root
-        display.vvv(f"jailexec: jail {name!r} root is {root}", host=name)
-        return root
-
-    def _jail_path(self, path):
-        """Map a path inside the jail to its absolute path on the host."""
+    @staticmethod
+    def _in_jail_path(path):
+        """Normalize to an absolute path as seen from inside the jail."""
+        path = str(path or "")
+        if not path.strip():
+            raise AnsibleError("Path cannot be empty")
         ensure_no_traversal(path)
-        root = self._resolve_jail_root()
-        return posixpath.normpath(posixpath.join(root, path.lstrip("/")))
+        return posixpath.normpath("/" + path.lstrip("/"))
+
+    @staticmethod
+    def _staging_path():
+        return posixpath.join(STAGING_DIR, f"{STAGING_PREFIX}{os.urandom(12).hex()}")
 
     # ---- exec / transfer -------------------------------------------------
 
@@ -291,45 +261,69 @@ class Connection(SSHConnection):
         if not cmd or not str(cmd).strip():
             raise AnsibleError("Command cannot be empty")
 
-        argv = [*self._privesc_argv(), "jexec"]
-        if self.jail_user != "root":
-            argv += ["-u", self.jail_user]
-        argv += [self.jail_name, "/bin/sh", "-c", cmd]
-        wrapped = _shelljoin(*argv)
+        wrapped = _shelljoin(*self._jexec_argv(), "/bin/sh", "-c", cmd)
 
         display.vvv(f"jailexec: exec [{self.jail_name}]: {cmd}", host=self.jail_name)
         return super().exec_command(wrapped, in_data=in_data, sudoable=sudoable)
 
     def put_file(self, in_path, out_path):
-        dest = self._jail_path(out_path)
-        dest_dir = posixpath.dirname(dest)
-        staged = posixpath.join(STAGING_DIR, f"{STAGING_PREFIX}{os.urandom(12).hex()}")
+        dest = self._in_jail_path(out_path)
+        staged = self._staging_path()
 
         display.vvv(
             f"jailexec: put_file {in_path} -> jail:{out_path}", host=self.jail_name
         )
         super().put_file(in_path, staged)
-        # Single round-trip: mkdir + move. Both go through privilege
-        # escalation because the destination lives inside the jail root,
-        # which is typically only writable by root on the host (a no-op
-        # prefix when privilege_escalation is ``none`` and we're already root).
-        prefix = self._privesc_argv()
-        move = (
-            f"{_shelljoin(*prefix, 'mkdir', '-p', dest_dir)} && "
-            f"{_shelljoin(*prefix, 'mv', staged, dest)}"
+        # The write happens *inside* the jail: jexec confines mkdir/cat to
+        # the jail's root, so a symlink planted inside the jail cannot
+        # redirect a privileged write onto a host path. The staged file is
+        # handed over as stdin, opened host-side by the unprivileged SSH
+        # login shell. Single extra round trip on the happy path.
+        inner = (
+            f"mkdir -p {shlex.quote(posixpath.dirname(dest))} && "
+            f"cat > {shlex.quote(dest)}"
         )
-        rc, _, stderr = super().exec_command(move)
+        transfer = (
+            f"{_shelljoin(*self._jexec_argv(), '/bin/sh', '-c', inner)}"
+            f" < {shlex.quote(staged)} && rm -f {shlex.quote(staged)}"
+        )
+        # sudoable=False keeps the SSH layer from waiting for an Ansible
+        # become prompt (and from allocating a tty) on plugin-internal
+        # commands; same below.
+        rc, _, stderr = super().exec_command(transfer, sudoable=False)
         if rc != 0:
             # Best-effort cleanup of the orphan staged file; ignore failures.
-            super().exec_command(f"rm -f {shlex.quote(staged)}")
+            super().exec_command(f"rm -f {shlex.quote(staged)}", sudoable=False)
             raise AnsibleError(
                 f"put_file to jail:{out_path} failed: "
                 f"{_decode(stderr).strip() or 'unknown error'}"
             )
 
     def fetch_file(self, in_path, out_path):
-        src = self._jail_path(in_path)
+        src = self._in_jail_path(in_path)
+        staged = self._staging_path()
+
         display.vvv(
             f"jailexec: fetch_file jail:{in_path} -> {out_path}", host=self.jail_name
         )
-        super().fetch_file(src, out_path)
+        # Mirror image of put_file: read inside the jail (symlinks cannot
+        # leak host files, and root-only files are readable when jail_user
+        # is root), stage on the host, then pull the staged copy over SFTP.
+        # ``cat < src`` instead of an argument rules out option injection;
+        # umask keeps the staged copy private to the SSH user.
+        inner = f"cat < {shlex.quote(src)}"
+        read = (
+            f"umask 077; {_shelljoin(*self._jexec_argv(), '/bin/sh', '-c', inner)}"
+            f" > {shlex.quote(staged)}"
+        )
+        rc, _, stderr = super().exec_command(read, sudoable=False)
+        if rc != 0:
+            super().exec_command(f"rm -f {shlex.quote(staged)}", sudoable=False)
+            raise AnsibleError(
+                f"fetch_file from jail:{in_path} failed: "
+                f"{_decode(stderr).strip() or 'unknown error'}"
+            )
+        try:
+            super().fetch_file(staged, out_path)
+        finally:
+            super().exec_command(f"rm -f {shlex.quote(staged)}", sudoable=False)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ansible-jailexec',
-    version='1.3.0',
+    version='2.0.0',
     author='Christian Hofstede-Kuhn',
     author_email='christian@hofstede.it',
     description='Ansible connection plugin for FreeBSD jails via jexec over SSH',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def make_conn():
     created = []
 
     def _make(options=None, remote_addr="testjail"):
-        ssh_exec = MagicMock(return_value=(0, b"/jail/testjail\n", b""))
+        ssh_exec = MagicMock(return_value=(0, b"", b""))
         ssh_put = MagicMock(return_value=None)
         ssh_fetch = MagicMock(return_value=None)
         ssh_close = MagicMock(return_value=None)

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -9,7 +9,7 @@ To run the integration tests in GitHub Actions, you need to configure the follow
 ### Required Secrets
 
 1. **FREEBSD_HOST**: The IPv6 address or hostname of your FreeBSD server
-   - Example: `2a13:e3c1:400e:1337::672`
+   - Example: `2001:db8::10`
 
 2. **FREEBSD_USER**: The SSH username for connecting to the FreeBSD host
    - Example: `ansible`
@@ -21,7 +21,7 @@ To run the integration tests in GitHub Actions, you need to configure the follow
    - Copy the entire private key content including headers
 
 4. **FREEBSD_HOST_KEY**: The SSH host key of your FreeBSD server
-   - Get it with: `ssh-keyscan -t ed25519 2a13:e3c1:400e:1337::672`
+   - Get it with: `ssh-keyscan -t ed25519 2001:db8::10`
    - This prevents SSH host verification issues
 
 ## Setting up GitHub Secrets
@@ -40,12 +40,29 @@ To run the tests locally:
    cp test-inventory.ini.example test-inventory.ini
    ```
 
-2. Edit `test-inventory.ini` with your FreeBSD server details
+2. Edit `test-inventory.ini` with your FreeBSD server details. Note:
+   - The inventory hostname is the **jail name** (override with `ansible_jail_name`).
+   - `ansible_jail_host` is **required** — it is the FreeBSD host running the jail.
+   - The SSH user needs a passwordless `doas` (or `sudo`) rule for `jexec` on the
+     host, e.g. `permit nopass ansible as root cmd jexec` — or set
+     `ansible_jail_privilege_escalation=none` if you SSH in as root.
 
 3. Run the smoke tests:
    ```bash
    ansible-playbook -i test-inventory.ini smoke-test.yml -v
    ```
+
+If a task fails with `Failed to create temporary directory`, the `jexec`
+wrapper itself is failing on the host. Re-run with `-vvvv` to see the stderr,
+or reproduce it manually:
+
+```bash
+ssh <user>@<jail-host> 'doas jexec <jail-name> /bin/sh -c id'
+```
+
+Typical causes: the jail isn't running or is named differently (`jls` on the
+host shows the real names), the `doas`/`sudo` rule for `jexec` is missing, or
+`doas` prompts for a password (use `permit nopass`).
 
 ## Test Coverage
 

--- a/tests/integration/smoke-test.yml
+++ b/tests/integration/smoke-test.yml
@@ -1,24 +1,20 @@
 ---
 - name: Smoke tests for jailexec connection plugin
-  hosts: testjail
-  gather_facts: no
+  hosts: all
+  gather_facts: false
+  vars:
+    smoke_file: /tmp/ansible-jailexec-smoke.txt
+    smoke_content: "jailexec smoke test payload\n"
+    fetch_dest: /tmp/ansible-jailexec-smoke-fetched-{{ inventory_hostname }}.txt
   tasks:
     - name: Test basic connectivity with ping
       ansible.builtin.ping:
       register: ping_result
 
-    - name: Display ping result
-      ansible.builtin.debug:
-        var: ping_result
-
     - name: Get hostname inside jail
       ansible.builtin.command: hostname
       register: hostname_result
       changed_when: false
-
-    - name: Display hostname
-      ansible.builtin.debug:
-        msg: "Jail hostname: {{ hostname_result.stdout }}"
 
     - name: Check FreeBSD version
       ansible.builtin.command: uname -a
@@ -27,50 +23,59 @@
 
     - name: Display system information
       ansible.builtin.debug:
-        msg: "System info: {{ uname_result.stdout }}"
+        msg: "Jail '{{ hostname_result.stdout }}': {{ uname_result.stdout }}"
 
-    - name: Test Python availability in jail
-      ansible.builtin.command: "{{ ansible_python_interpreter | default('/usr/local/bin/python3') }} --version"
-      register: python_version
-      changed_when: false
-
-    - name: Display Python version
-      ansible.builtin.debug:
-        msg: "Python version: {{ python_version.stdout }}"
-
-    - name: Verify doas privilege escalation works
+    - name: Verify commands run as the expected jail user
       ansible.builtin.command: whoami
-      become: yes
-      register: whoami_root
+      register: whoami_result
       changed_when: false
 
-    - name: Assert running as root with doas
+    - name: Assert jail user
       ansible.builtin.assert:
         that:
-          - whoami_root.stdout == "root"
-        fail_msg: "Privilege escalation with doas failed"
+          - whoami_result.stdout == (ansible_jail_user | default('root'))
+        fail_msg: "Expected to run as {{ ansible_jail_user | default('root') }}, got {{ whoami_result.stdout }}"
 
-    - name: Test file creation in jail
-      ansible.builtin.file:
-        path: /tmp/ansible-test-{{ ansible_date_time.epoch }}
-        state: touch
-      register: file_creation
+    - name: Write a file into the jail (exercises put_file)
+      ansible.builtin.copy:
+        content: "{{ smoke_content }}"
+        dest: "{{ smoke_file }}"
+        mode: "0644"
 
-    - name: Verify file was created
-      ansible.builtin.stat:
-        path: "{{ file_creation.path }}"
-      register: file_stat
+    - name: Read the file back inside the jail (exercises exec path)
+      ansible.builtin.slurp:
+        src: "{{ smoke_file }}"
+      register: slurped
 
-    - name: Assert file exists
+    - name: Assert in-jail content round-trips
       ansible.builtin.assert:
         that:
-          - file_stat.stat.exists
-        fail_msg: "Test file was not created successfully"
+          - slurped.content | b64decode == smoke_content
+        fail_msg: "File content inside the jail does not match what was copied"
 
-    - name: Clean up test file
+    - name: Fetch the file to the controller (exercises fetch_file)
+      ansible.builtin.fetch:
+        src: "{{ smoke_file }}"
+        dest: "{{ fetch_dest }}"
+        flat: true
+      register: fetched
+
+    - name: Assert fetched content matches
+      ansible.builtin.assert:
+        that:
+          - fetched.checksum == smoke_content | hash('sha1')
+        fail_msg: "Fetched file content does not match"
+
+    - name: Clean up test file in the jail
       ansible.builtin.file:
-        path: "{{ file_creation.path }}"
+        path: "{{ smoke_file }}"
         state: absent
+
+    - name: Clean up fetched file on the controller
+      ansible.builtin.file:
+        path: "{{ fetch_dest }}"
+        state: absent
+      delegate_to: localhost
 
     - name: Test command with specific working directory
       ansible.builtin.command: pwd
@@ -88,8 +93,8 @@
     - name: Summary
       ansible.builtin.debug:
         msg: |
-          All smoke tests passed successfully!
+          All smoke tests passed!
           - Ping: {{ ping_result.ping }}
           - Hostname: {{ hostname_result.stdout }}
-          - File operations: Success
-          - Command execution: Success
+          - Jail user: {{ whoami_result.stdout }}
+          - put_file / slurp / fetch_file round-trip: OK

--- a/tests/integration/test-inventory.ini.example
+++ b/tests/integration/test-inventory.ini.example
@@ -1,14 +1,23 @@
+# Copy to test-inventory.ini and adjust for your environment.
+#
+# The INVENTORY HOSTNAME is the JAIL NAME on the FreeBSD host (override with
+# ansible_jail_name if they differ). ansible_jail_host is REQUIRED and points
+# at the FreeBSD host that runs the jail.
 [jails]
-# Example inventory for FreeBSD jail testing
-# Replace with your actual FreeBSD server details
-testjail ansible_host=2a13:e3c1:400e:1337::672 ansible_user=ansible ansible_connection=jailexec ansible_python_interpreter=/usr/local/bin/python3
+testjail ansible_connection=jailexec ansible_jail_host=jail-host.example.com ansible_python_interpreter=/usr/local/bin/python3
 
 [jails:vars]
-# SSH connection settings
-ansible_ssh_private_key_file=~/.ssh/id_rsa
-ansible_ssh_common_args='-o StrictHostKeyChecking=yes'
-# Privilege escalation settings for jexec
-ansible_become_method=doas
-ansible_become=yes
-# Optional: specify the jail host if different from ansible_host
-# jail_host=2a13:e3c1:400e:1337::672
+# SSH settings for reaching the jail HOST (every option of the built-in ssh
+# plugin works here).
+ansible_user=ansible
+ansible_ssh_private_key_file=~/.ssh/id_ed25519
+ansible_ssh_common_args='-o StrictHostKeyChecking=accept-new'
+
+# Host-side privilege escalation used to run jexec: doas (default), sudo, or
+# none (when ansible_user is already root on the host).
+#ansible_jail_privilege_escalation=doas
+
+# User to run tasks as inside the jail (default: root). Note: do NOT set
+# ansible_become=yes globally -- that would require doas/sudo to be installed
+# inside the jail for every task.
+#ansible_jail_user=root

--- a/tests/test_command_execution.py
+++ b/tests/test_command_execution.py
@@ -38,7 +38,7 @@ class TestExecWrapping:
         assert parts == [
             "doas",
             "jexec",
-            "-u",
+            "-U",  # -U = jail's password database; -u would be the host's
             "postgres",
             "testjail",
             "/bin/sh",
@@ -77,7 +77,7 @@ class TestExecWrapping:
         parts = shlex.split(_last_exec_cmd(conn))
         assert parts == [
             "jexec",
-            "-u",
+            "-U",
             "postgres",
             "testjail",
             "/bin/sh",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,9 +1,9 @@
-"""Tests for connection lifecycle, properties, and jail-root resolution."""
+"""Tests for connection lifecycle and properties."""
 
 from __future__ import annotations
 
 import pytest
-from ansible.errors import AnsibleConnectionFailure, AnsibleError
+from ansible.errors import AnsibleConnectionFailure
 
 
 class TestConnect:
@@ -25,108 +25,43 @@ class TestConnect:
         conn._connect()
         conn.ssh_connect_mock.assert_called_once()
 
-    def test_connect_does_not_probe_eagerly(self, make_conn):
-        """Regression: connect must not issue an SSH round trip.
-
-        The jail-root probe is deferred until the first file operation so that
-        exec-only workloads don't pay for the lookup and so that probing can't
-        recurse through ``@ensure_connect``.
-        """
+    def test_connect_issues_no_remote_commands(self, make_conn):
+        """Connect must stay free of extra SSH round trips."""
         conn = make_conn()
         conn._connect()
         assert conn._connected is True
-        assert conn._jail_root is None
         conn.ssh_exec.assert_not_called()
 
-    def test_close_resets_cache(self, make_conn):
+    def test_close_delegates_to_ssh(self, make_conn):
         conn = make_conn()
         conn._connect()
-        conn._jail_root = "/jail/testjail"
         conn.close()
-        assert conn._jail_root is None
         conn.ssh_close_mock.assert_called_once()
 
 
-class TestJailRootProbe:
-    def test_caches_across_calls(self, make_conn):
-        conn = make_conn()
-        conn._connect()
-        conn.ssh_exec.return_value = (0, b"/jail/testjail\n", b"")
+class TestJailRootDeprecation:
+    """``ansible_jail_root`` is obsolete: transfers run inside the jail now."""
 
-        assert conn._resolve_jail_root() == "/jail/testjail"
-        assert conn._resolve_jail_root() == "/jail/testjail"
-        conn.ssh_exec.assert_called_once()
+    @pytest.fixture
+    def warnings(self, monkeypatch):
+        import jailexec
 
-    def test_uses_privesc_and_jail_name(self, make_conn):
-        conn = make_conn(
-            {"privilege_escalation": "sudo", "jail_name": "blog"},
+        captured = []
+        monkeypatch.setattr(
+            jailexec.display, "warning", lambda msg, **kw: captured.append(msg)
         )
-        conn._connect()
-        conn.ssh_exec.return_value = (0, b"/jails/blog\n", b"")
+        return captured
 
-        conn._resolve_jail_root()
-
-        cmd = conn.ssh_exec.call_args.args[0]
-        assert cmd == "sudo jls -j blog path"
-
-    def test_none_privesc_probes_without_wrapper(self, make_conn):
-        conn = make_conn({"privilege_escalation": "none", "jail_name": "blog"})
-        conn._connect()
-        conn.ssh_exec.return_value = (0, b"/jails/blog\n", b"")
-
-        conn._resolve_jail_root()
-
-        cmd = conn.ssh_exec.call_args.args[0]
-        assert cmd == "jls -j blog path"
-
-    def test_missing_jail_fails_clearly(self, make_conn):
-        conn = make_conn()
-        conn._connect()
-        conn.ssh_exec.return_value = (1, b"", b"jls: jail not found\n")
-        with pytest.raises(AnsibleConnectionFailure, match="Cannot access jail"):
-            conn._resolve_jail_root()
-
-    def test_empty_root_fails(self, make_conn):
-        conn = make_conn()
-        conn._connect()
-        conn.ssh_exec.return_value = (0, b"", b"")
-        with pytest.raises(AnsibleConnectionFailure, match="no filesystem root"):
-            conn._resolve_jail_root()
-
-    def test_whitespace_only_root_fails(self, make_conn):
-        """Regression: ``b"\\n"`` used to IndexError before the fix."""
-        conn = make_conn()
-        conn._connect()
-        conn.ssh_exec.return_value = (0, b"\n", b"")
-        with pytest.raises(AnsibleConnectionFailure, match="no filesystem root"):
-            conn._resolve_jail_root()
-
-    def test_override_skips_probe(self, make_conn):
+    def test_setting_jail_root_warns_and_still_connects(self, make_conn, warnings):
         conn = make_conn({"jail_root": "/mnt/jails/web"})
         conn._connect()
+        assert conn._connected is True
+        assert any("ansible_jail_root is deprecated" in w for w in warnings)
 
-        assert conn._resolve_jail_root() == "/mnt/jails/web"
-        conn.ssh_exec.assert_not_called()
-
-    def test_override_is_normalized(self, make_conn):
-        conn = make_conn({"jail_root": "  /mnt/jails/web/  "})
+    def test_no_warning_when_unset(self, make_conn, warnings):
+        conn = make_conn()
         conn._connect()
-
-        assert conn._resolve_jail_root() == "/mnt/jails/web"
-
-    def test_override_rejects_traversal(self, make_conn):
-        conn = make_conn({"jail_root": "/mnt/../etc"})
-        conn._connect()
-
-        with pytest.raises(AnsibleError, match="traversal"):
-            conn._resolve_jail_root()
-
-    def test_override_rejects_relative(self, make_conn):
-        conn = make_conn({"jail_root": "jails/web"})
-        conn._connect()
-
-        with pytest.raises(AnsibleConnectionFailure, match="absolute path"):
-            conn._resolve_jail_root()
+        assert warnings == []
 
 
 class TestProperties:
@@ -137,6 +72,30 @@ class TestProperties:
     def test_jail_name_override(self, make_conn):
         conn = make_conn({"jail_name": "explicit"}, remote_addr="ignored")
         assert conn.jail_name == "explicit"
+
+    def test_jail_name_is_inventory_hostname_not_ansible_host(self, make_conn):
+        """Regression: with ``ansible_host`` set, remote_addr is the host's
+        address, and the plugin used to run ``jexec <ip>`` instead of using
+        the inventory hostname as the jail name."""
+        conn = make_conn(remote_addr="192.0.2.10")
+        conn.set_options(
+            var_options={
+                "ansible_jail_host": "192.0.2.10",
+                "inventory_hostname": "wiki",
+            }
+        )
+        assert conn.jail_name == "wiki"
+
+    def test_explicit_jail_name_beats_inventory_hostname(self, make_conn):
+        conn = make_conn()
+        conn.set_options(
+            var_options={
+                "ansible_jail_host": "jail-host.example.com",
+                "inventory_hostname": "wiki",
+                "ansible_jail_name": "blog",
+            }
+        )
+        assert conn.jail_name == "blog"
 
     def test_jail_user_default(self, make_conn):
         assert make_conn().jail_user == "root"

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -1,89 +1,105 @@
-"""Tests for put_file / fetch_file."""
+"""Tests for put_file / fetch_file.
+
+Transfers run *inside* the jail (``jexec ... /bin/sh -c 'cat ...'``) with the
+host-side staging file wired up via shell redirection. This keeps privileged
+writes/reads confined to the jail's chroot, so symlinks planted inside the
+jail cannot redirect them onto host paths.
+"""
 
 from __future__ import annotations
 
 import re
-import shlex
 
 import pytest
 from ansible.errors import AnsibleError
 
+STAGED = r"/tmp/ansible-jailexec-[0-9a-f]+"
 
-def _connect_with_cached_root(make_conn, options=None):
-    """Open a connection and pre-seed the jail-root cache.
 
-    The jail-root probe is lazy -- it fires on the first file op. Tests that
-    are *only* about file-op round-trip shape want to pin the root so the
-    probe doesn't show up in assertions about call counts / commands.
-    """
+def _connected(make_conn, options=None):
     conn = make_conn(options)
     conn._connect()
-    conn._jail_root = "/jail/testjail"
     conn.ssh_exec.reset_mock()
     return conn
 
 
 class TestPutFile:
-    def test_stages_then_moves_in_one_round_trip(self, make_conn):
-        conn = _connect_with_cached_root(make_conn)
-        conn.ssh_exec.return_value = (0, b"", b"")
+    def test_stages_then_writes_inside_jail_in_one_round_trip(self, make_conn):
+        conn = _connected(make_conn)
 
         conn.put_file("/local/foo", "/etc/foo.conf")
 
-        # 1 put_file (scp) + 1 exec_command (mkdir && mv)
+        # 1 put_file (sftp) + 1 exec_command (jexec mkdir + cat + rm).
         conn.ssh_put.assert_called_once()
         assert conn.ssh_exec.call_count == 1
 
         in_path, staged = conn.ssh_put.call_args.args
         assert in_path == "/local/foo"
-        assert re.match(r"/tmp/ansible-jailexec-[0-9a-f]+$", staged)
+        assert re.fullmatch(STAGED, staged)
 
-        move_cmd = conn.ssh_exec.call_args.args[0]
-        # Both halves use privilege escalation and target the jail root.
-        assert "doas mkdir -p /jail/testjail/etc" in move_cmd
-        assert "doas mv" in move_cmd
-        assert "/jail/testjail/etc/foo.conf" in move_cmd
+        cmd = conn.ssh_exec.call_args.args[0]
+        m = re.fullmatch(
+            r"doas jexec testjail /bin/sh -c "
+            r"'mkdir -p /etc && cat > /etc/foo\.conf' "
+            rf"< ({STAGED}) && rm -f \1",
+            cmd,
+        )
+        assert m, cmd
+        # stdin is wired to the very file that was staged.
+        assert m.group(1) == staged
+        # Internal commands must not engage become prompt handling.
+        assert conn.ssh_exec.call_args.kwargs == {"sudoable": False}
 
-    def test_probes_jail_root_on_first_file_op(self, make_conn):
-        """First file op pays the probe cost; subsequent ones don't."""
-        conn = make_conn()
-        conn._connect()
-        # jls probe then mkdir+mv.
-        conn.ssh_exec.side_effect = [
-            (0, b"/jail/testjail\n", b""),
-            (0, b"", b""),
-        ]
+    def test_nonroot_jail_user_writes_as_that_user(self, make_conn):
+        conn = _connected(make_conn, {"jail_user": "postgres"})
 
-        conn.put_file("/local/foo", "/etc/foo.conf")
+        conn.put_file("/local/foo", "/var/db/foo")
 
-        assert conn.ssh_exec.call_count == 2
-        assert conn.ssh_exec.call_args_list[0].args[0] == "doas jls -j testjail path"
-        assert conn._jail_root == "/jail/testjail"
+        cmd = conn.ssh_exec.call_args.args[0]
+        assert "doas jexec -U postgres testjail" in cmd
 
-    def test_none_privesc_omits_wrapper_in_move(self, make_conn):
-        conn = _connect_with_cached_root(make_conn, {"privilege_escalation": "none"})
-        conn.ssh_exec.return_value = (0, b"", b"")
+    def test_none_privesc_omits_wrapper(self, make_conn):
+        conn = _connected(make_conn, {"privilege_escalation": "none"})
 
         conn.put_file("/local/foo", "/etc/foo.conf")
 
-        move_cmd = conn.ssh_exec.call_args.args[0]
-        assert "doas" not in move_cmd and "sudo" not in move_cmd
-        assert re.fullmatch(
-            r"mkdir -p /jail/testjail/etc && "
-            r"mv /tmp/ansible-jailexec-[0-9a-f]+ /jail/testjail/etc/foo\.conf",
-            move_cmd,
+        cmd = conn.ssh_exec.call_args.args[0]
+        assert cmd.startswith("jexec testjail ")
+        assert "doas" not in cmd and "sudo" not in cmd
+
+    def test_relative_dest_is_rooted_at_jail_root(self, make_conn):
+        conn = _connected(make_conn)
+
+        conn.put_file("/local/x", "etc/foo")
+
+        cmd = conn.ssh_exec.call_args.args[0]
+        assert "cat > /etc/foo" in cmd
+
+    def test_quotes_unsafe_destination_paths(self, make_conn):
+        import shlex
+
+        conn = _connected(make_conn)
+
+        conn.put_file("/local/x", "/etc/with space/foo;rm")
+
+        # Unwrap the outer quoting; the in-jail script must quote both paths.
+        tokens = shlex.split(conn.ssh_exec.call_args.args[0])
+        assert tokens[:5] == ["doas", "jexec", "testjail", "/bin/sh", "-c"]
+        assert tokens[5] == (
+            "mkdir -p '/etc/with space' && cat > '/etc/with space/foo;rm'"
         )
 
     def test_rejects_traversal(self, make_conn):
-        conn = _connect_with_cached_root(make_conn)
+        conn = _connected(make_conn)
         with pytest.raises(AnsibleError, match="traversal"):
             conn.put_file("/local/x", "/etc/../foo")
+        conn.ssh_put.assert_not_called()
 
-    def test_cleans_up_on_move_failure(self, make_conn):
-        conn = _connect_with_cached_root(make_conn)
-        # First call (mkdir+mv) fails; second (cleanup rm) succeeds.
+    def test_cleans_up_on_write_failure(self, make_conn):
+        conn = _connected(make_conn)
+        # First call (jexec cat) fails; second (cleanup rm) succeeds.
         conn.ssh_exec.side_effect = [
-            (1, b"", b"mv: permission denied"),
+            (1, b"", b"cat: permission denied"),
             (0, b"", b""),
         ]
 
@@ -91,23 +107,68 @@ class TestPutFile:
             conn.put_file("/local/x", "/etc/foo")
 
         assert conn.ssh_exec.call_count == 2
-        assert "rm -f" in conn.ssh_exec.call_args_list[-1].args[0]
+        rm_call = conn.ssh_exec.call_args_list[-1]
+        assert re.fullmatch(rf"rm -f {STAGED}", rm_call.args[0])
+        assert rm_call.kwargs == {"sudoable": False}
 
 
 class TestFetchFile:
-    def test_single_round_trip(self, make_conn):
-        conn = _connect_with_cached_root(make_conn)
-        conn.ssh_fetch.reset_mock()
+    def test_reads_inside_jail_then_fetches_staged_copy(self, make_conn):
+        conn = _connected(make_conn)
 
         conn.fetch_file("/etc/hosts", "/local/hosts")
 
-        conn.ssh_fetch.assert_called_once_with(
-            "/jail/testjail/etc/hosts", "/local/hosts"
+        # 1 exec (jexec cat -> staging) + 1 fetch (sftp) + 1 exec (cleanup).
+        assert conn.ssh_exec.call_count == 2
+
+        read_call = conn.ssh_exec.call_args_list[0]
+        m = re.fullmatch(
+            r"umask 077; doas jexec testjail /bin/sh -c "
+            rf"'cat < /etc/hosts' > ({STAGED})",
+            read_call.args[0],
         )
-        # No extra exec_command round-trips (no test -f pre-check).
-        conn.ssh_exec.assert_not_called()
+        assert m, read_call.args[0]
+        assert read_call.kwargs == {"sudoable": False}
+
+        conn.ssh_fetch.assert_called_once_with(m.group(1), "/local/hosts")
+        assert conn.ssh_exec.call_args_list[1].args[0] == f"rm -f {m.group(1)}"
+
+    def test_fetch_honors_jail_user(self, make_conn):
+        conn = _connected(make_conn, {"jail_user": "www"})
+
+        conn.fetch_file("/var/log/nginx/access.log", "/local/access.log")
+
+        read_cmd = conn.ssh_exec.call_args_list[0].args[0]
+        assert "doas jexec -U www testjail" in read_cmd
+
+    def test_read_failure_cleans_staging_and_raises(self, make_conn):
+        conn = _connected(make_conn)
+        conn.ssh_exec.side_effect = [
+            (1, b"", b"cat: /nope: No such file or directory"),
+            (0, b"", b""),
+        ]
+
+        with pytest.raises(AnsibleError, match="fetch_file .* failed"):
+            conn.fetch_file("/nope", "/local/x")
+
+        conn.ssh_fetch.assert_not_called()
+        assert re.fullmatch(
+            rf"rm -f {STAGED}", conn.ssh_exec.call_args_list[-1].args[0]
+        )
+
+    def test_staging_removed_even_if_sftp_fetch_fails(self, make_conn):
+        conn = _connected(make_conn)
+        conn.ssh_fetch.side_effect = AnsibleError("sftp blew up")
+
+        with pytest.raises(AnsibleError, match="sftp blew up"):
+            conn.fetch_file("/etc/hosts", "/local/hosts")
+
+        assert re.fullmatch(
+            rf"rm -f {STAGED}", conn.ssh_exec.call_args_list[-1].args[0]
+        )
 
     def test_rejects_traversal(self, make_conn):
-        conn = _connect_with_cached_root(make_conn)
+        conn = _connected(make_conn)
         with pytest.raises(AnsibleError, match="traversal"):
             conn.fetch_file("/etc/../shadow", "/local/x")
+        conn.ssh_exec.assert_not_called()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -7,10 +7,10 @@ from ansible.errors import AnsibleConnectionFailure, AnsibleError
 
 from jailexec import (
     JAIL_NAME_RE,
+    Connection,
     _decode,
     ensure_no_traversal,
     validate_jail_name,
-    validate_jail_root,
 )
 
 
@@ -93,34 +93,31 @@ def test_jail_name_regex_pattern():
     assert not JAIL_NAME_RE.match(".bad")
 
 
-class TestValidateJailRoot:
+class TestInJailPath:
+    """Paths are normalized to absolute in-jail paths before quoting."""
+
     @pytest.mark.parametrize(
         "path,expected",
         [
-            ("/jail/web", "/jail/web"),
-            ("  /jail/web  ", "/jail/web"),
-            ("/jail/web/", "/jail/web"),
-            ("/jail//web", "/jail/web"),
+            ("/etc/foo.conf", "/etc/foo.conf"),
+            ("etc/foo.conf", "/etc/foo.conf"),
+            ("//etc//foo", "/etc/foo"),
+            ("/etc/foo/", "/etc/foo"),
             ("/", "/"),
         ],
     )
-    def test_valid(self, path, expected):
-        assert validate_jail_root(path) == expected
+    def test_normalizes(self, path, expected):
+        assert Connection._in_jail_path(path) == expected
 
     @pytest.mark.parametrize("path", ["", "   ", None])
     def test_empty_rejected(self, path):
-        with pytest.raises(AnsibleConnectionFailure, match="cannot be empty"):
-            validate_jail_root(path)
+        with pytest.raises(AnsibleError, match="empty"):
+            Connection._in_jail_path(path)
 
-    @pytest.mark.parametrize("path", ["relative/path", "jail/web", "./jail"])
-    def test_relative_rejected(self, path):
-        with pytest.raises(AnsibleConnectionFailure, match="absolute path"):
-            validate_jail_root(path)
-
-    @pytest.mark.parametrize("path", ["/jail/../etc", "/../escape", "/a/b/../c"])
+    @pytest.mark.parametrize("path", ["/etc/../foo", "../escape", ".."])
     def test_traversal_rejected(self, path):
         with pytest.raises(AnsibleError, match="traversal"):
-            validate_jail_root(path)
+            Connection._in_jail_path(path)
 
 
 class TestDecode:


### PR DESCRIPTION
## Summary

Security release. The headline fix closes a **jail-escape vulnerability** in file transfers; several correctness bugs are fixed alongside it, and the docs/changelog are overhauled. Verified end-to-end against a real FreeBSD 15.0 jail.

A full security advisory will accompany the tagged release.

## Security fix

`put_file` previously resolved the destination to a host-side path (`<jail_root>/<dest>`) and ran `mkdir -p` / `mv` there **as root**. Those commands follow symlinks, so a compromised jail could plant a symlink (e.g. point its `/usr/local/etc` at the host's `/etc`) and turn any playbook copy through that path into a root-owned write to an arbitrary **host** file — escaping the jail.

Transfers now execute **inside** the jail via `jexec`:
- `put_file`: `jexec <jail> /bin/sh -c 'mkdir -p <dir> && cat > <dest>' < <staged>`
- `fetch_file`: `jexec <jail> /bin/sh -c 'cat < <src>' > <staged>` (staged `umask 077`), then SFTP down

All path resolution is confined to the jail's chroot, so an in-jail symlink can't reach the host filesystem.

## Other fixes

- **Default jail name is the inventory hostname**, not the connection address. Previously `web ansible_host=192.0.2.10 …` ran `jexec "192.0.2.10"` and failed with `jail not found`.
- **`ansible_jail_user` uses `jexec -U`** (jail's password database) instead of `-u` (host's), matching documented behavior.
- **`fetch_file` now uses privilege escalation**, so root-only files inside the jail are fetchable.
- **Internal commands pass `sudoable=False`**, avoiding become-prompt hangs and needless `-tt` pty allocation.

## Changed / deprecated

- Transfers run as `ansible_jail_user` inside the jail (use `become` for root-owned paths).
- Host-side privilege now only needs a `jexec` doas/sudo rule; `jls`/`mkdir`/`mv`/`rm` rules can be removed.
- The `jls` jail-root probe is gone. `ansible_jail_root` is deprecated and ignored (warns when set).

## Testing

- Unit suite rewritten for the in-jail design: **88 tests, 100% coverage**; black/isort/flake8/bandit clean.
- **Integration smoke test passed against a real FreeBSD 15.0-RELEASE jail**, now round-tripping a file through `copy` → `slurp` → `fetch`.
- `python -m build` + `twine check` pass; sdist/wheel no longer package local test inventories.

## Upgrade notes

See the "Upgrading from 1.x" section in the README and the `2.0.0` CHANGELOG entry. For the common `ansible_jail_user=root` setup, no inventory changes are needed beyond trimming doas/sudoers to the single `jexec` rule.